### PR TITLE
Add ability to --index --and-quit

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ bind: '0.0.0.0'
 autoh1: true
 highlighter: true
 line_numbers: true
+index: false
 ```
 
 

--- a/lib/madness/command_line.rb
+++ b/lib/madness/command_line.rb
@@ -5,14 +5,9 @@ module Madness
     include Singleton
     include Colsole
 
-    # Without any argument, we run the server in the current directory.
-    # Otherwise, we will set some options before executing.
+    # Launch the server
     def execute(argv=[])
-      if argv.empty?
-        launch_server
-      else
-        launch_server_with_options argv
-      end
+      launch_server_with_options argv
     end
 
     private
@@ -24,11 +19,10 @@ module Madness
       begin
         args = Docopt::docopt(doc, argv: argv, version: VERSION)
         set_config args
-        if args['--index']
-          build_index
-        else
-          launch_server
-        end
+
+        build_index if config.index
+        launch_server unless args['--and-quit']
+
       rescue Docopt::Exit => e
         puts e.message
       end
@@ -42,7 +36,7 @@ module Madness
         STDERR.puts "Invalid path (#{config.path})" 
         return
       end
-      
+
       show_status
       Server.prepare
       Server.run!
@@ -57,6 +51,7 @@ module Madness
       config.autoh1       = false  if args['--no-auto-h1']
       config.highlighter  = false  if args['--no-syntax']
       config.line_numbers = false  if args['--no-line-numbers']
+      config.index        = true   if args['--index']
     end
 
     # Say hello to everybody when the server starts, showing the known 
@@ -64,7 +59,7 @@ module Madness
     def show_status
       say_status :start, 'the madness'
       say_status :listen, "#{config.bind}:#{config.port}", :txtblu
-      say_status :path, config.path, :txtblu
+      say_status :path, File.realpath(config.path), :txtblu
       say_status :use, config.filename if config.file_exist?
       say "-" * 40
     end

--- a/lib/madness/docopt.txt
+++ b/lib/madness/docopt.txt
@@ -29,8 +29,12 @@ Options:
   --index
     Build or rebuild the index for the search page.
 
+  --and-quit
+    Quit after building the index (applicable only with --index).
+
 Examples:
   madness
   madness docs
   madness docs --no-auto-h1 -p 4567
+  madness --index --and-quit
 

--- a/lib/madness/settings.rb
+++ b/lib/madness/settings.rb
@@ -10,7 +10,7 @@ module Madness
     include Singleton
 
     attr_accessor :port, :bind, :path, :autoh1, 
-      :highlighter, :line_numbers
+      :highlighter, :line_numbers, :index
 
     def initialize
       reset
@@ -41,6 +41,7 @@ module Madness
       self.autoh1 = true
       self.highlighter = true
       self.line_numbers = true
+      self.index = false
     end
 
     def load_from_file

--- a/spec/fixtures/.madness.yml
+++ b/spec/fixtures/.madness.yml
@@ -6,3 +6,4 @@ bind: '4.3.2.1'
 autoh1: false
 highlighter: false
 line_numbers: false
+index: true

--- a/spec/madness/command_line_spec.rb
+++ b/spec/madness/command_line_spec.rb
@@ -50,9 +50,18 @@ describe CommandLine do
     end
 
     context "with --index" do
-      it "calls the index builder" do
+      it "calls the index builder and starts the server" do
+        expect(Server).to receive :run!
         expect_any_instance_of(Search).to receive :build_index
         command = %w[--index]
+        expect {cli.execute command}.to output(/done.*indexing.*start.*the madness/m).to_stdout
+      end
+    end
+
+    context "with --index --and-quit" do
+      it "calls the index builder" do
+        expect_any_instance_of(Search).to receive :build_index
+        command = %w[--index --and-quit]
         expect {cli.execute command}.to output(/done.*indexing/).to_stdout
       end
     end

--- a/spec/madness/settings_spec.rb
+++ b/spec/madness/settings_spec.rb
@@ -24,6 +24,7 @@ describe Settings do
       expect(config.autoh1).to be false
       expect(config.highlighter).to be false
       expect(config.line_numbers).to be false
+      expect(config.index).to be true
     end
   end
 


### PR DESCRIPTION
- Change the behavior of the `--index` parameter. It will now NOT exit, but rather start the server after indexing.
- Add `--and-quit` flag, which when combined with `--index` will have the old behavior (i.e. index then quit).