### PR TITLE
Switch to Sinatra 2 and drop rack-contrib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: ruby
 
 rvm:
-  - 2.1.0
+  - 2.2.0
   - 2.3.1
+  - 2.4.1
 
 script: bundle exec rspec
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: ruby
 
 rvm:
-  - 2.2.0
+  - 2.2.2
   - 2.3.1
-  - 2.4.1
+  - 2.4.2
 
 script: bundle exec rspec
 

--- a/lib/madness.rb
+++ b/lib/madness.rb
@@ -11,7 +11,6 @@ require 'sinatra/reloader'
 require 'sass/plugin/rack'
 require 'docopt'
 require 'colsole'
-require 'rack/contrib/try_static'
 require 'ferret'
 
 require 'madness/version'

--- a/lib/madness.rb
+++ b/lib/madness.rb
@@ -14,6 +14,7 @@ require 'colsole'
 require 'ferret'
 
 require 'madness/version'
+require 'madness/try_static'
 require 'madness/settings'
 require 'madness/server_helper'
 require 'madness/server_base'

--- a/lib/madness/server_base.rb
+++ b/lib/madness/server_base.rb
@@ -24,7 +24,7 @@ module Madness
     # The CommandLine class and the test suite should both call
     # `Server.prepare` before calling Server.run!
     def self.prepare
-      use Rack::TryStatic, :root => "#{config.path}/public/", :urls => %w[/]
+      set :public_folder, "#{config.path}/public/"
       set :bind, config.bind
       set :port, config.port
     end

--- a/lib/madness/server_base.rb
+++ b/lib/madness/server_base.rb
@@ -24,7 +24,7 @@ module Madness
     # The CommandLine class and the test suite should both call
     # `Server.prepare` before calling Server.run!
     def self.prepare
-      set :public_folder, "#{config.path}/public/"
+      use TryStatic, root: "#{config.path}/public/", :urls => %w[/]
       set :bind, config.bind
       set :port, config.port
     end

--- a/lib/madness/try_static.rb
+++ b/lib/madness/try_static.rb
@@ -1,0 +1,39 @@
+module Madness
+  # This class allows multiple public folders so that we can load our 
+  # CSS from the gem-domain public folder, and other things from the 
+  # user-domain public folder
+  # 
+  # TryStatic is borrowed from rack-contrib, since the gem is out of date
+  # and does not work with Sinatra 2
+  # 
+  # It is used in `server_base.rb` like so:
+  #
+  #     use TryStatic, :root => "#{config.path}/public/", :urls => %w[/]
+  # 
+  # Ref:
+  # - https://stackoverflow.com/questions/18966318/sinatra-multiple-public-directories
+  # - https://github.com/rack/rack-contrib/blob/master/lib/rack/contrib/try_static.rb
+  # - https://github.com/rack/rack-contrib/pull/129
+  #
+  class TryStatic
+    def initialize(app, options)
+      @app = app
+      @try = ['', *options[:try]]
+      # :nocov:
+      @static = ::Rack::Static.new(
+        lambda { |_| [404, {}, []] },
+        options)
+      # :nocov:
+    end
+
+    def call(env)
+      orig_path = env['PATH_INFO']
+      found = nil
+      @try.each do |path|
+        resp = @static.call(env.merge!({'PATH_INFO' => orig_path + path}))
+        break if !(403..405).include?(resp[0]) && found = resp
+      end
+      found or @app.call(env.merge!('PATH_INFO' => orig_path))
+    end
+  end
+end

--- a/madness.gemspec
+++ b/madness.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.executables = ["madness"]
   s.homepage    = 'https://github.com/DannyBen/madness'
   s.license     = 'MIT'
-  s.required_ruby_version = ">= 2.2.0"
+  s.required_ruby_version = ">= 2.2.2"
 
   s.add_runtime_dependency 'sass', '~> 3.4'
   s.add_runtime_dependency 'sinatra', '~> 2.0'

--- a/madness.gemspec
+++ b/madness.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.executables = ["madness"]
   s.homepage    = 'https://github.com/DannyBen/madness'
   s.license     = 'MIT'
-  s.required_ruby_version = ">= 2.1.0"
+  s.required_ruby_version = ">= 2.2.0"
 
   s.add_runtime_dependency 'sass', '~> 3.4'
   s.add_runtime_dependency 'sinatra', '~> 2.0'

--- a/madness.gemspec
+++ b/madness.gemspec
@@ -18,9 +18,8 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.1.0"
 
   s.add_runtime_dependency 'sass', '~> 3.4'
-  s.add_runtime_dependency 'sinatra', '~> 1.4'
-  s.add_runtime_dependency 'sinatra-contrib', '~> 1.4'
-  s.add_runtime_dependency 'rack-contrib', '~> 1.4'
+  s.add_runtime_dependency 'sinatra', '~> 2.0'
+  s.add_runtime_dependency 'sinatra-contrib', '~> 2.0'
   s.add_runtime_dependency 'slim', '~> 3.0'
   s.add_runtime_dependency 'rdiscount', '~> 2.2'
   s.add_runtime_dependency 'coderay', '~> 1.1'
@@ -30,11 +29,12 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'puma', '~> 3.8'
 
   s.add_development_dependency 'runfile', '~> 0.9'
+  s.add_development_dependency 'rack-test', '~> 0.7'
   s.add_development_dependency 'runfile-tasks', '~> 0.4'
-  s.add_development_dependency 'byebug', '~> 9.0'
+  s.add_development_dependency 'byebug', '~> 9.1'
   s.add_development_dependency 'rspec', '~> 3.5'
   s.add_development_dependency 'rdoc', '~> 5.1'
-  s.add_development_dependency 'simplecov', '~> 0.14'
+  s.add_development_dependency 'simplecov', '~> 0.15'
   s.add_development_dependency 'yard', '~> 0.9'
   s.add_development_dependency 'rspec-html-matchers', '~> 0.9'
 end

--- a/spec/madness/sass_spec.rb
+++ b/spec/madness/sass_spec.rb
@@ -16,6 +16,12 @@ describe Server do
       get '/css/main.css'
       expect(File).to exist css      
     end
+
+    it "serves css" do
+      get '/css/main.css'
+      expect(last_response.content_type).to eq "text/css;charset=utf-8"
+      expect(last_response.body).to match /font-family/
+    end
   end
 
 end


### PR DESCRIPTION
This PR upgrades to Sinatra 2 and stops using rack-contrib, since it does not work with Sinatra 2 / Rack 2, and there is a [year-long open PR][1].

### Notable changes

- Minimum Ruby version is now 2.2.2.
- No longer using `rack-contrib`, instead we have a copy of `TryStatic` for multiple public locations
- Add tests to ensure both public locations are responding properly

[1]: https://github.com/rack/rack-contrib/pull/129