### PR TITLE
Fix invalid docopt example

### DIFF
--- a/lib/madness/docopt.txt
+++ b/lib/madness/docopt.txt
@@ -41,6 +41,6 @@ Examples:
   madness
   madness docs
   madness docs --no-auto-h1 -p 4567
-  madness docs --production
+  madness docs --development
   madness --index --and-quit
 


### PR DESCRIPTION
The docopt showed a `madness --production` example which no longer exists.