### PR TITLE
Stop tampering with links

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Feature Highlights
 
 - Easy to use
 - Built in full text search
-- Built in GraphViz diagram generator
+- Compatible with how markdown files are displayed on GitHub andGitHub pages.
 - Configure with a configuration file or command arguments
 
 
@@ -129,10 +129,7 @@ You can put images and any other asset file anywhere in your documentation
 folder.
 
 When linking to other pages or images in your documentation folder, simply
-use the URL relative to the markdown file. Madness will convert these to be
-relative to the docroot of the generated site.
-
-This behavior mimics how GitHub is rendering markdown files.
+use the URL relative to the markdown file. 
 
 For example, if you have a folder named `subfolder` that contains a 
 `README.md` and a `nice-picture.png`, showing it in your `README` is done by
@@ -161,15 +158,18 @@ will be automatically added based on the file name.
 Hidden Directories
 --------------------------------------------------
 
-Directories that begin with an underscore will not be displayed in the
-navigation.
+These directories will not be displayed in the navigation:
+
+- Directories that begin with an underscore.
+- Directories that are made only of lowercase letters, underscoew, dash and/or 
+  numbers (`/^[a-z_\-0-9]+$/`).
 
 
 
 Docker Image
 --------------------------------------------------
 
-This gem is also available as a docker image.
+Madness server is also available as a docker image.
 
 This command will start the server on localhost:3000, with the current 
 directory as the markdown documentation folder

--- a/lib/madness/navigation.rb
+++ b/lib/madness/navigation.rb
@@ -45,7 +45,7 @@ module Madness
       dirs  = Dir["#{dir}/*"].select { |f| File.directory? f }
       dirs.reject! do |f| 
         basename = File.basename(f)
-        basename[0] == '_'
+        basename[0] == '_' or basename =~ /^[a-z_\-0-9]+$/
       end
       dirs
     end

--- a/lib/madness/server.rb
+++ b/lib/madness/server.rb
@@ -17,9 +17,13 @@ module Madness
     get '/*' do
       path = params[:splat].first
 
-      doc = Document.new path
+      doc     = Document.new path
       dir     = doc.dir
       content = doc.content
+
+      if doc.type == :readme and !path.empty? and path[-1] != '/'
+        redirect "#{path}/"
+      end
 
       nav = Navigation.new(dir)
       breadcrumbs = Breadcrumbs.new(path).links

--- a/spec/fixtures/docroot/Links Folder/Page.md
+++ b/spec/fixtures/docroot/Links Folder/Page.md
@@ -1,7 +1,0 @@
-# Links
-
-![pic](ok.png)
-[link](somewhere.html)
-[tel](tel:55512345)
-[external](http://example.com)
-[absolute](/abso.loot)

--- a/spec/fixtures/docroot/Links Folder/README.md
+++ b/spec/fixtures/docroot/Links Folder/README.md
@@ -1,7 +1,0 @@
-# Links
-
-![pic](ok.png)
-[link](somewhere.html)
-[tel](tel:55512345)
-[external](http://example.com)
-[absolute](/abso.loot)

--- a/spec/fixtures/docroot/Links.md
+++ b/spec/fixtures/docroot/Links.md
@@ -1,7 +1,0 @@
-# Links
-
-![pic](ok.png)
-[link](somewhere.html)
-[tel](tel:55512345)
-[external](http://example.com)
-[absolute](/abso.loot)

--- a/spec/madness/document_spec.rb
+++ b/spec/madness/document_spec.rb
@@ -70,17 +70,6 @@ describe Document do
       expect(doc.content).not_to include ' &amp; '
     end
 
-    it "does not alter URLs that begin with a slash" do
-      doc = Document.new "Links Folder/Page"
-      expect(doc.content).to have_tag 'a', with: { href: '/abso.loot' }
-    end
-
-    it "does not alter URLs that contain a colon" do
-      doc = Document.new "Links Folder/Page"
-      expect(doc.content).to have_tag 'a', with: { href: 'tel:55512345' }
-      expect(doc.content).to have_tag 'a', with: { href: 'http://example.com' }
-    end
-
     context "with auto h1 disabled" do
       it "does not add h1" do
         config.autoh1 = false
@@ -88,30 +77,5 @@ describe Document do
         expect(doc.content).not_to have_tag :h1
       end
     end
-
-    context "with a file in the root path" do
-      it "does not alter relative URLs" do
-        doc = Document.new "Links"
-        expect(doc.content).to have_tag 'a', with: { href: 'somewhere.html' }
-        expect(doc.content).to have_tag 'img', with: { src: 'ok.png' }
-      end
-    end
-
-    context "with a README file in a subfolder" do
-      it "modifies relative URLs to be relative to docroot" do
-        doc = Document.new "Links Folder"
-        expect(doc.content).to have_tag 'a', with: { href: '/Links%20Folder/somewhere.html' }
-        expect(doc.content).to have_tag 'img', with: { src: '/Links%20Folder/ok.png' }
-      end
-    end
-
-    context "with a regular file in a subfolder" do
-      it "modifies relative URLs to be relative to docroot" do
-        doc = Document.new "Links Folder/Page"
-        expect(doc.content).to have_tag 'a', with: { href: '/Links%20Folder/somewhere.html' }
-        expect(doc.content).to have_tag 'img', with: { src: '/Links%20Folder/ok.png' }
-      end
-    end
-
   end
 end

--- a/spec/madness/server_spec.rb
+++ b/spec/madness/server_spec.rb
@@ -51,13 +51,19 @@ describe Server do
 
     context "in subfolders" do
       it "works" do
-        get '/Folder'
+        get '/Folder/'
         expect(last_response).to be_ok
         expect(last_response.body).to have_tag 'h1', text: "Sub folder #1"
       end
 
-      it "shows breadcrumbs" do
+      it "redirects to have a trailing slash" do
         get '/Folder'
+        expect(last_response).to be_redirection
+        expect(last_response.location).to eq 'http://example.org/Folder/'
+      end
+
+      it "shows breadcrumbs" do
+        get '/Folder/'
         expect(last_response.body).to have_tag '.breadcrumbs' do
           with_tag 'a', text: 'Home'
           with_tag 'span', text: 'Folder'
@@ -106,7 +112,7 @@ describe Server do
       end
 
       it "does not redirect if the file is README" do
-        get '/No%20Redirect'
+        get '/No%20Redirect/'
         expect(last_response).to be_ok
         expect(last_response.body).to have_tag 'p', text: "Was not redirected"
       end


### PR DESCRIPTION
This PR replaces the way we handle relative links.

Instead of modifying the link, we are now acting exactly like GitHub pages - if we are looking at a folder (i.e. its actually showing its README), then the URL will be appended with a trailing slash. This way the webserver will know how to serve relative assets.

In this PR code was removed and not added, while the functionality stayed the same.

In addition - **all lowercase folders are now also ignored in the navigation**. In order to allow having `css` or `images` folders.