### PR TITLE
Search improvements

### DIFF
--- a/lib/madness/refinements/string_refinements.rb
+++ b/lib/madness/refinements/string_refinements.rb
@@ -1,8 +1,12 @@
 module Madness
   module StringRefinements
     refine String do
+      def remove(regex)
+        gsub regex, ''
+      end
+
       def to_slug
-        downcase.strip.gsub(' ', '-').gsub(/[^\w-]/, '')
+        downcase.strip.gsub(' ', '-').remove(/[^\w-]/)
       end
 
       # This is here so we can have one place that defines how to convert
@@ -12,7 +16,7 @@ module Madness
       # just removes any numbers followed by a dot at the beginning of the 
       # string, in order to allow "The Invisible Sorting Hand".
       def to_label
-        gsub(/^\d+\.\s+/, '').gsub(/\.md$/, '')
+        remove(/^\d+\.\s+/).remove(/\.md$/)
       end
     end
   end

--- a/spec/fixtures/search/Twins/README.md
+++ b/spec/fixtures/search/Twins/README.md
@@ -1,0 +1,1 @@
+Julius Benedict and Vincent Benedict are twins, the result of a secret experiment carried out at a genetics laboratory to combine the DNA of six fathers to produce the perfect child.

--- a/spec/fixtures/search/Twins/index.md
+++ b/spec/fixtures/search/Twins/index.md
@@ -1,0 +1,1 @@
+Julius Benedict and Vincent Benedict are twins, the result of a secret experiment carried out at a genetics laboratory to combine the DNA of six fathers to produce the perfect child.

--- a/spec/fixtures/search/With README/README.md
+++ b/spec/fixtures/search/With README/README.md
@@ -1,0 +1,1 @@
+Ruby is a dynamic, interpreted, reflective, object-oriented, general-purpose programming language. It was designed and developed in the mid-1990s by Yukihiro "Matz" Matsumoto in Japan.

--- a/spec/fixtures/search/With index/index.md
+++ b/spec/fixtures/search/With index/index.md
@@ -1,0 +1,1 @@
+Ruby is a dynamic, interpreted, reflective, object-oriented, general-purpose programming language. It was designed and developed in the mid-1990s by Yukihiro "Matz" Matsumoto in Japan.

--- a/spec/madness/refinements/string_refinements_spec.rb
+++ b/spec/madness/refinements/string_refinements_spec.rb
@@ -3,6 +3,14 @@ require 'spec_helper'
 describe StringRefinements do
   using StringRefinements
 
+  describe '#remove' do
+    subject { "not an excellent example" }
+
+    it "removes the matching pattern" do
+      expect(subject.remove(/^not | excellent/)).to eq 'an example'
+    end    
+  end
+
   describe '#to_slug' do
     subject { "String with !23@  " }
 

--- a/spec/madness/search_spec.rb
+++ b/spec/madness/search_spec.rb
@@ -70,12 +70,12 @@ describe Search do
 
     it "removes trailing /README and /index from files" do
       results = search.search('ruby').map { |r| r[:file] }
-      expect(results).to eq ["With index", "With README"]
+      expect(results.sort).to eq ["With README", "With index"]
     end
 
     it "removes trailing /README and /index from labels" do
       results = search.search('ruby').map { |r| r[:label] }
-      expect(results).to eq ["With index", "With README"]
+      expect(results.sort).to eq ["With README", "With index"]
     end
   end
 


### PR DESCRIPTION
This PR makes some adjustments to the search and indexing mechnism:

- In case both `README`.md and `index.md` exist in the same folder, only `index.md` will be indexed
- Search results will come back with trailing `/README` and `/index` omitted (closes #70)
- Search spec was updated accordingly, and with some minor semantic refactoring

In addition, since we are using quite a lot of `string.gsub(/regex/, '')`, a new string refinement was added to achieve the same with `string.remove /regex/` 