### PR TITLE
Downgrade Sinatra

### DIFF
--- a/madness.gemspec
+++ b/madness.gemspec
@@ -17,6 +17,9 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
   s.required_ruby_version = ">= 2.2.2"
 
+  # we are locking sinatra to 2.0.3 due to this issue:
+  # https://github.com/sinatra/sinatra/issues/1476
+  s.add_runtime_dependency 'sinatra', '2.0.3'
   s.add_runtime_dependency 'coderay', '~> 1.1'
   s.add_runtime_dependency 'colsole', '~> 0.4'
   s.add_runtime_dependency 'commonmarker', '~> 0.17'
@@ -28,7 +31,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'rack-contrib', '~> 2.0'
   s.add_runtime_dependency 'requires', '~> 0.1'
   s.add_runtime_dependency 'sass', '~> 3.4'
-  s.add_runtime_dependency 'sinatra', '~> 2.0'
   s.add_runtime_dependency 'sinatra-contrib', '~> 2.0'
   s.add_runtime_dependency 'slim', '~> 3.0'
 


### PR DESCRIPTION
Sinatra 2.0.4 started issuing a warning related to ActiveSupport. Until this is removed, or we find the time to see how to bypass it, we are locking to 2.0.3.

Reference: https://github.com/sinatra/sinatra/issues/1476