### PR TITLE
Update sinatra to 2.0.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,7 @@ env:
   - CC_TEST_REPORTER_ID=22697375d978d2b0cea8ef21c3102d24df2d12ed3ce495fd9aa26bfd9be80241
 
 rvm:
-  - "2.2.2"
-  - "2.4.2"
+  - "2.3.0"
   - "2.5.0"
 
 addons:

--- a/Gemfile
+++ b/Gemfile
@@ -8,9 +8,7 @@ group :development do
   # CmomonMarker (it requires a lower version than we need)
   # gem 'github-pages', group: :jekyll_plugins
 
-
   gem 'byebug'
-  gem 'github_changelog_generator'
   gem 'rack-test'
   gem 'rdoc'
   gem 'rspec'

--- a/madness.gemspec
+++ b/madness.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.executables = ["madness"]
   s.homepage    = 'https://github.com/DannyBen/madness'
   s.license     = 'MIT'
-  s.required_ruby_version = ">= 2.2.2"
+  s.required_ruby_version = ">= 2.3.0"
 
   s.add_runtime_dependency 'coderay', '~> 1.1'
   s.add_runtime_dependency 'colsole', '~> 0.5'

--- a/madness.gemspec
+++ b/madness.gemspec
@@ -17,9 +17,6 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
   s.required_ruby_version = ">= 2.2.2"
 
-  # we are locking sinatra to 2.0.3 due to this issue:
-  # https://github.com/sinatra/sinatra/issues/1476
-  s.add_runtime_dependency 'sinatra', '2.0.3'
   s.add_runtime_dependency 'coderay', '~> 1.1'
   s.add_runtime_dependency 'colsole', '~> 0.5'
   s.add_runtime_dependency 'commonmarker', '~> 0.18'
@@ -29,9 +26,10 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'naturally', '~> 2.1'
   s.add_runtime_dependency 'puma', '~> 3.11'
   s.add_runtime_dependency 'rack-contrib', '~> 2.0'
+  s.add_runtime_dependency 'rack-ssl', '~> 1.4'
   s.add_runtime_dependency 'requires', '~> 0.1'
   s.add_runtime_dependency 'sass', '~> 3.4'
-  s.add_runtime_dependency 'sinatra-contrib', '~> 2.0'
+  s.add_runtime_dependency 'sinatra', '~> 2.0', '>= 2.0.5'
+  s.add_runtime_dependency 'sinatra-contrib', '~> 2.0', '>= 2.0.5'
   s.add_runtime_dependency 'slim', '~> 4.0'
-  s.add_runtime_dependency 'rack-ssl', '~> 1.4'
 end


### PR DESCRIPTION
Now that https://github.com/sinatra/sinatra/pull/1477 has been released, and the warning is gone - we can once again use the latest Sinatra.

In addition, this PR drops support for Ruby < 2.3