### PR TITLE
Add --open flag to launch browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ line_numbers: true
 index: false
 toc: Table of Contents
 theme: _theme
+open: false
 ```
 
 For convenience, you can get a template config file by running:

--- a/lib/madness/browser.rb
+++ b/lib/madness/browser.rb
@@ -1,0 +1,62 @@
+require 'socket'
+require 'os'
+
+module Madness
+  # Handles browser launching
+  class Browser
+    attr_reader :host, :port
+
+    def initialize(host, port)
+      @host, @port = host, port
+    end
+
+    # Returns a URL based on host, port nad MADNESS_FORCE_SSL.
+    def server_url
+      scheme = ENV['MADNESS_FORCE_SSL'] ? 'https' : 'http'
+      url_host = ['0.0.0.0', '127.0.0.1'].include?(host) ? 'localhost' : host
+      "#{scheme}://#{url_host}:#{port}"
+    end
+
+    # Returns true if the server is running. Will attempt to connect
+    # multiple times. This is designed to assisn in running some code after
+    # the server has launched.
+    def server_running?(retries: 5, delay: 1)
+      connected = false
+      attempts = 0
+
+      begin
+        connected = Socket.tcp(host, port)
+      rescue
+        sleep delay
+        retry if (attempts += 1) < retries
+      ensure
+        connected.close if connected
+      end
+
+      !!connected
+    end
+
+    # Open a web browser if the server is running. This is done in a
+    # non-blocking manner, so it can be executed before starting the server.
+    def open
+      fork do
+        if server_running?
+          success = open!
+          yield success ? nil : "Failed opening browser (#{open_command.join ' '})"
+        else
+          yield "Failed connecting to #{server_url}. Is the server running?"
+        end
+      end
+    end
+
+    # Run the appropriate command (based on OS) to open a browser.
+    # Will display a helpful message on failure.
+    def open!
+      system *open_command, out: File::NULL, err: File::NULL
+    end
+
+    def open_command
+      @open_command ||= [OS.open_file_command, server_url]
+    end
+  end
+end

--- a/lib/madness/browser.rb
+++ b/lib/madness/browser.rb
@@ -10,7 +10,7 @@ module Madness
       @host, @port = host, port
     end
 
-    # Returns a URL based on host, port nad MADNESS_FORCE_SSL.
+    # Returns a URL based on host, port and MADNESS_FORCE_SSL.
     def server_url
       scheme = ENV['MADNESS_FORCE_SSL'] ? 'https' : 'http'
       url_host = ['0.0.0.0', '127.0.0.1'].include?(host) ? 'localhost' : host
@@ -52,7 +52,7 @@ module Madness
 
     # Runs the appropriate command (based on OS) to open a browser.
     def open!
-      system *open_command, out: File::NULL, err: File::NULL
+      system *open_command, out: File::NULL, err: File::NULL, in: File::NULL
     end
 
     # Returns the appropriate command (based on OS) to open a browser.

--- a/lib/madness/browser.rb
+++ b/lib/madness/browser.rb
@@ -52,7 +52,7 @@ module Madness
 
     # Runs the appropriate command (based on OS) to open a browser.
     def open!
-      system *open_command, out: File::NULL, err: File::NULL, in: File::NULL
+      system *open_command, err: File::NULL, in: File::NULL, out: File::NULL
     end
 
     # Returns the appropriate command (based on OS) to open a browser.

--- a/lib/madness/browser.rb
+++ b/lib/madness/browser.rb
@@ -18,7 +18,7 @@ module Madness
     end
 
     # Returns true if the server is running. Will attempt to connect
-    # multiple times. This is designed to assisn in running some code after
+    # multiple times. This is designed to assist in running some code after
     # the server has launched.
     def server_running?(retries: 5, delay: 1)
       connected = false
@@ -38,6 +38,7 @@ module Madness
 
     # Open a web browser if the server is running. This is done in a
     # non-blocking manner, so it can be executed before starting the server.
+    # It will yield an error message if it fails, or nil on success.
     def open
       fork do
         if server_running?
@@ -49,12 +50,12 @@ module Madness
       end
     end
 
-    # Run the appropriate command (based on OS) to open a browser.
-    # Will display a helpful message on failure.
+    # Runs the appropriate command (based on OS) to open a browser.
     def open!
       system *open_command, out: File::NULL, err: File::NULL
     end
 
+    # Returns the appropriate command (based on OS) to open a browser.
     def open_command
       @open_command ||= [OS.open_file_command, server_url]
     end

--- a/lib/madness/command_line.rb
+++ b/lib/madness/command_line.rb
@@ -37,8 +37,8 @@ module Madness
       end
     end
 
-    # Execute some pre-server-launch operations if needed, and execute
-    # the server.
+    # Execute some pre-server-launch operations if needed, execute the
+    # server, and launch the browser if requested.
     def launch_server_with_options(args)
       set_config args
       generate_stuff
@@ -123,6 +123,7 @@ module Madness
       search.build_index
     end
 
+    # Generate the table of contents file
     def build_toc
       say_status :toc, "generating #{config.toc}"
       TableOfContents.new.build(config.toc)
@@ -132,6 +133,8 @@ module Madness
       @config ||= Settings.instance
     end
 
+    # Returns the URL where madness is running, suitable for opening in the
+    # browser
     def server_url
       scheme = ENV['MADNESS_FORCE_SSL'] ? 'https' : 'http'
       host = config.bind == '0.0.0.0' ? 'localhost' : config.bind
@@ -140,6 +143,9 @@ module Madness
       "#{scheme}://#{host}:#{port}"
     end
 
+    # Returns truthy if the server is running. Will attempt to connect 
+    # multiple times. This is designed to assisn in running some code after
+    # the server has launched.
     def server_running?(retries: 5, delay: 1)
       connected = false
       attempts = 0
@@ -154,10 +160,14 @@ module Madness
       connected
     end
 
+    # Open a web browser if the server is running. This is done in a
+    # non-blocking manner, so it can be executed before starting the server.
     def open_browser
       fork { open_browser! if server_running? }
     end
 
+    # Run the appropriate command (based on OS) to open a browser.
+    # Will display a helpful message on failure.
     def open_browser!
       command = [OS.open_file_command, server_url]
       success = system *command, out: File::NULL, err: File::NULL

--- a/lib/madness/command_line.rb
+++ b/lib/madness/command_line.rb
@@ -2,6 +2,7 @@ require 'fileutils'
 require 'singleton'
 require 'colsole'
 require 'docopt'
+require 'os'
 
 module Madness
 
@@ -126,6 +127,18 @@ module Madness
 
     def config
       @config ||= Settings.instance
+    end
+
+    def open_url args
+      url = ENV['MADNESS_FORCE_SSL'] ? 'https://%s:%s' : 'http://%s:%s'
+      url = url % [config.bind, config.port]
+
+      begin
+        system(OS.open_file_command, url)
+      rescue Exception => e
+        say "!txtred!Error: Could not open a URL:"
+        say "!txtred!  #{e.to_s}"
+      end
     end
   end
 end

--- a/lib/madness/command_line.rb
+++ b/lib/madness/command_line.rb
@@ -29,10 +29,20 @@ module Madness
     # the server.
     def handle(args)
       if args['create']
+        say "Ignoring `--open` when `create` is called." if args['--open']
         create_config if args['config']
         create_theme(args['FOLDER']) if args['theme']
       else
         launch_server_with_options args
+      end
+
+      if args['--open'] && !args['create']
+        begin
+          open_url(args)
+          Process.wait 
+        rescue Interrupt => e
+          # We want to be able SIG*-terminate without big fuzz.
+        end
       end
     end
 

--- a/lib/madness/command_line.rb
+++ b/lib/madness/command_line.rb
@@ -143,7 +143,7 @@ module Madness
       "#{scheme}://#{host}:#{port}"
     end
 
-    # Returns truthy if the server is running. Will attempt to connect 
+    # Returns true if the server is running. Will attempt to connect
     # multiple times. This is designed to assisn in running some code after
     # the server has launched.
     def server_running?(retries: 5, delay: 1)
@@ -155,15 +155,23 @@ module Madness
       rescue
         sleep delay
         retry if (attempts += 1) < retries
+      ensure
+        connected.close if connected
       end
 
-      connected
+      !!connected
     end
 
     # Open a web browser if the server is running. This is done in a
     # non-blocking manner, so it can be executed before starting the server.
     def open_browser
-      fork { open_browser! if server_running? }
+      fork do
+        if server_running?
+          open_browser!
+        else
+          say "!txtylw!Failed launching browser. Is the server running?"
+        end
+      end
     end
 
     # Run the appropriate command (based on OS) to open a browser.

--- a/lib/madness/docopt.txt
+++ b/lib/madness/docopt.txt
@@ -65,9 +65,8 @@ Options:
     (Config option: toc)
 
   --open
-    Try to open a browser session pointing at the madness webserver. Ignored
-    if a `create` subcommand is given.
-    (Config option: open_browser_at_start)
+    Open the browser pointing at the madness webserver.
+    (Config option: open)
 
   --and-quit
     Quit instead of running the server. Useful with --index or --toc.

--- a/lib/madness/docopt.txt
+++ b/lib/madness/docopt.txt
@@ -64,6 +64,11 @@ Options:
     Generate a table of contents file. 
     (Config option: toc)
 
+  --open
+    Try to open a browser session pointing at the madness webserver. Ignored
+    if a `create` subcommand is given.
+    (Config option: open_browser_at_start)
+
   --and-quit
     Quit instead of running the server. Useful with --index or --toc.
 
@@ -71,6 +76,7 @@ Examples:
   madness
   madness docs
   madness docs --no-auto-h1 -p 4567
+  madness docs --open
   madness --no-sidebar --no-auto-nav
   madness --index --and-quit
   madness --toc "Table of Contents.md" --index --and-quit

--- a/lib/madness/settings.rb
+++ b/lib/madness/settings.rb
@@ -52,7 +52,6 @@ module Madness
         index: false,
         theme: nil,
         open: false,
-
         auto_nav: true,
         sidebar: true
       }

--- a/lib/madness/settings.rb
+++ b/lib/madness/settings.rb
@@ -51,6 +51,7 @@ module Madness
         line_numbers: true,
         index: false,
         theme: nil,
+        open: false,
 
         auto_nav: true,
         sidebar: true

--- a/lib/madness/templates/madness.yml
+++ b/lib/madness/templates/madness.yml
@@ -12,3 +12,4 @@
 # index: false
 # toc: Table of Contents
 # theme: _theme
+# open: false

--- a/madness.gemspec
+++ b/madness.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'ferret', '~> 0.11'
   s.add_runtime_dependency 'json', '~> 2.1'
   s.add_runtime_dependency 'naturally', '~> 2.2'
+  s.add_runtime_dependency 'os', '~> 1.0'
   s.add_runtime_dependency 'puma', '~> 4.0'
   s.add_runtime_dependency 'rack-contrib', '~> 2.1'
   s.add_runtime_dependency 'rack-ssl', '~> 1.4'

--- a/spec/fixtures/cli/help
+++ b/spec/fixtures/cli/help
@@ -64,6 +64,10 @@ Options:
     Generate a table of contents file. 
     (Config option: toc)
 
+  --open
+    Open the browser pointing at the madness webserver.
+    (Config option: open)
+
   --and-quit
     Quit instead of running the server. Useful with --index or --toc.
 
@@ -71,6 +75,7 @@ Examples:
   madness
   madness docs
   madness docs --no-auto-h1 -p 4567
+  madness docs --open
   madness --no-sidebar --no-auto-nav
   madness --index --and-quit
   madness --toc "Table of Contents.md" --index --and-quit

--- a/spec/madness/browser_spec.rb
+++ b/spec/madness/browser_spec.rb
@@ -41,7 +41,7 @@ describe Browser do
     end
   end
 
-  describe '#open', :focus do
+  describe '#open' do
     context "when the server is not running" do
       it "yields an error message" do
         expect(subject).to receive(:fork) do |&block|

--- a/spec/madness/browser_spec.rb
+++ b/spec/madness/browser_spec.rb
@@ -1,0 +1,93 @@
+require 'spec_helper'
+
+describe Browser do
+  let(:host) { '127.0.0.1' }
+  subject { described_class.new host, 3456 }
+
+  describe '#server_url' do
+    it "returns a url string" do
+      expect(subject.server_url).to eq "http://localhost:3456"
+    end
+
+    context "when host is 0.0.0.0" do
+      it "converts it to 'localhost'" do
+        expect(subject.server_url).to eq "http://localhost:3456"
+      end
+    end
+
+    context "when host is not a localhost address" do
+      let(:host) { "1.2.3.4" }
+
+      it "returns it as is" do
+        expect(subject.server_url).to eq "http://1.2.3.4:3456"
+      end
+    end
+  end
+
+  describe '#server_running?' do
+    let(:mock_socket) { Class.new { def close; end }.new }
+    
+    it "attempts to connect several times and returns true on success" do
+      expect(Socket).to receive(:tcp).with(subject.host, subject.port).and_raise "cannot connect"
+      expect(Socket).to receive(:tcp).with(subject.host, subject.port).and_return mock_socket
+      expect(subject.server_running?).to be true
+    end
+
+    context "when it fails to connect" do
+      it "returns false" do
+        expect(Socket).to receive(:tcp).with(subject.host, subject.port).and_return false
+        expect(subject.server_running?).to be false
+      end
+    end
+  end
+
+  describe '#open', :focus do
+    context "when the server is not running" do
+      it "yields an error message" do
+        expect(subject).to receive(:fork) do |&block|
+          expect(subject).to receive(:server_running?).and_return false
+          block.call
+        end
+
+        expect{ |b| subject.open &b }.to yield_with_args("Failed connecting to http://localhost:3456. Is the server running?")
+      end
+    end
+
+    context "when the server is running but the launch command fails" do
+      it "yields an error message" do
+        expect(subject).to receive(:fork) do |&block|
+          expect(subject).to receive(:server_running?).and_return true
+          expect(subject).to receive(:open!).and_return false
+          block.call
+        end
+
+        expect{ |b| subject.open &b }.to yield_with_args("Failed opening browser (xdg-open http://localhost:3456)")
+      end
+    end
+
+    context "when the server is running and the launch command succeeds" do
+      it "yields nil" do
+        expect(subject).to receive(:fork) do |&block|
+          expect(subject).to receive(:server_running?).and_return true
+          expect(subject).to receive(:open!).and_return true
+          block.call
+        end
+
+        expect{ |b| subject.open &b }.to yield_with_args(nil)
+      end
+    end
+  end
+
+  describe '#open!' do
+    it "runs the system command that opens the browser" do
+      expect(subject).to receive(:system).with("xdg-open", subject.server_url, anything)
+      subject.open!
+    end
+  end
+
+  describe '#open_command' do
+    it "returns a command in array form" do
+      expect(subject.open_command).to eq ["xdg-open", subject.server_url]
+    end
+  end
+end

--- a/spec/madness/command_line_spec.rb
+++ b/spec/madness/command_line_spec.rb
@@ -82,12 +82,21 @@ describe CommandLine do
     end
   end
 
-  context "with --open", :focus do
-    it "starts the server and executes a command to launch the browser" do
+  context "with --open" do
+    it "calls Browser#open" do
       expect(Server).to receive :run!
-      expect(subject).to receive(:server_running?).and_return true
+      expect_any_instance_of(Browser).to receive(:open).and_yield false
       command = %w[--open]
       expect { subject.execute command }.to output(/start.*the madnes/m).to_stdout
+    end
+
+    context "when browser launching fails" do
+      it "shows a friendly message" do
+        expect(Server).to receive :run!
+        expect_any_instance_of(Browser).to receive(:open).and_yield "this is a friendly message"
+        command = %w[--open]
+        expect { subject.execute command }.to output(/friendly message/m).to_stdout
+      end
     end
   end
 

--- a/spec/madness/command_line_spec.rb
+++ b/spec/madness/command_line_spec.rb
@@ -82,6 +82,15 @@ describe CommandLine do
     end
   end
 
+  context "with --open", :focus do
+    it "starts the server and executes a command to launch the browser" do
+      expect(Server).to receive :run!
+      expect(subject).to receive(:server_running?).and_return true
+      command = %w[--open]
+      expect { subject.execute command }.to output(/start.*the madnes/m).to_stdout
+    end
+  end
+
   context "with create config" do
     let(:filename) { '.madness.yml' }
 


### PR DESCRIPTION
This PR builds on #87 in order to achieve `madness --open` with minimal disruption.

Here is how it works:

1. There is a new `--open` and `config.open` flags. If any is true, we will attempt to start a browser after the server is running.
2. The server is launched in the main thread, since it is the main reason we are using madness.
3. The open browser functionality works by forking a short-lived process.
    - This process will attempt to connect to `localhost:3000` (or whatever is configured).
    - If it succeeds, it will run the appropriate system command to start the browser. STDOUT and STDERR are supressed.
        - In case the command fails, it will be displayed so the user can try it and see the errors it produces.
    - If it fails, it will try up to 5 times, sleeping 1 second between attempts.

### TODO:

- [x] Initial implementation
- [x] Current tests should pass
- [x] Extract all browser related functionality to a separate class for better testability and separation of concerns.
- [x] Add tests for `config.open` and `--open` - reach 100% coverage
- [x] Make sure `madness create config` creates a file with the new `open` option
- [x] Complete code documentation
- [x] Complete README documentation 
- [x] Review
- [ ] Release gem
- [ ] Release docker image
