### PR TITLE
Fix ffi-related failing tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,5 @@ addons:
 before_install:
 - gem install bundler
 
-before_script:
-- gem uninstall sassc
-- gem install sassc -- --disable-march-tune-native
-
 script:
 - bundle exec rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,9 @@ addons:
 before_install:
 - gem install bundler
 
+before_script:
+- gem uninstall sassc
+- gem install sassc -- --disable-march-tune-native
+
 script:
 - bundle exec rspec

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ group :development do
   gem 'runfile-tasks'
   gem 'simplecov'
   gem 'yard'
+  gem 'ffi' <= 1.11.2
   
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 group :development do
 
-  gem 'jekyll'
+  # gem 'jekyll'
 
   # This gem is for local GitHub pages development, but it conflicts with
   # CmomonMarker (it requires a lower version than we need)
@@ -18,7 +18,6 @@ group :development do
   gem 'runfile-tasks'
   gem 'simplecov'
   gem 'yard'
-  gem 'ffi', '< 1.11.3'
   
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ group :development do
   gem 'runfile-tasks'
   gem 'simplecov'
   gem 'yard'
-  gem 'ffi' <= 1.11.2
+  gem 'ffi', '< 1.11.3'
   
 end
 


### PR DESCRIPTION
Remove jekyll from dev dependencies, since it brings sassc which causes FFI compile errors in Rubies 2.4 and 2.6 for reasons beyond me.  Closest probably related issue is https://github.com/sass/sassc-ruby/issues/146