### PR TITLE
Add configurable search limit

### DIFF
--- a/lib/madness/command_line.rb
+++ b/lib/madness/command_line.rb
@@ -61,10 +61,12 @@ module Madness
     # Get the arguments as provided by docopt, and set them to our own
     # config object.
     def set_config(args)
-      config.path  = args['PATH']   if args['PATH']
-      config.port  = args['--port'].to_i if args['--port']
-      config.bind  = args['--bind'] if args['--bind']
-      config.toc   = args['--toc']  if args['--toc']
+      config.path         = args['PATH']   if args['PATH']
+      config.port         = args['--port'].to_i if args['--port']
+      config.bind         = args['--bind'] if args['--bind']
+      config.toc          = args['--toc']  if args['--toc']
+      config.search_limit = args['--search-limit'].to_i  if args['--search-limit']
+
       config.auto_h1      = false   if args['--no-auto-h1']
       config.auto_nav     = false   if args['--no-auto-nav']
       config.sidebar      = false   if args['--no-sidebar']
@@ -73,6 +75,7 @@ module Madness
       config.copy_code    = false   if args['--no-copy-code']
       config.index        = true    if args['--index']
       config.open         = true    if args['--open']
+      
       config.theme = File.expand_path(args['--theme'], config.path) if args['--theme']
     end
 

--- a/lib/madness/docopt.txt
+++ b/lib/madness/docopt.txt
@@ -16,16 +16,16 @@ Subcommands:
 
 Parameters:
   PATH:
-    Optional path to the markdown directory.
+    Path to the markdown directory [default: .].
     (Config option: path)
 
 Options:
   -p, --port NUMBER
-    Set server port number.
+    Set server port number [default: 3000].
     (Config option: port)
 
   -b, --bind ADDRESS
-    Set server listen address.
+    Set server listen address [default: 0.0.0.0].
     (Config option: bind)
 
   --no-auto-h1
@@ -67,6 +67,10 @@ Options:
   --toc FILE
     Generate a table of contents file. 
     (Config option: toc)
+
+  --search-limit LIMIT
+    Maximum number of results to show on the search page [default: 100].
+    (Config option: search_limit)
 
   --open
     Open the browser pointing at the madness webserver.

--- a/lib/madness/search.rb
+++ b/lib/madness/search.rb
@@ -33,7 +33,7 @@ module Madness
       index = Index.new path: index_dir
 
       results = []
-      index.search_each(query, limit: 20) do |doc_id, score| 
+      index.search_each(query, limit: config.search_limit) do |doc_id, score| 
         filename = index[doc_id][:file].sub("#{@path}/", '')[0...-3]
         highlights = index.highlight "content:(#{query.tr(' ',' OR ')}) ", doc_id, field: :content,
           pre_tag: "<strong>", post_tag: "</strong>",
@@ -89,6 +89,10 @@ module Madness
         .split('/')
         .map { |i| i.to_label }
         .join(' / ')
+    end
+
+    def config
+      @config ||= Settings.instance
     end
 
     def file_url(filename)

--- a/lib/madness/settings.rb
+++ b/lib/madness/settings.rb
@@ -49,6 +49,7 @@ module Madness
         auto_h1: true,
         highlighter: true,
         line_numbers: true,
+        search_limit: 100,
         copy_code: true,
         index: false,
         theme: nil,

--- a/lib/madness/templates/madness.yml
+++ b/lib/madness/templates/madness.yml
@@ -12,5 +12,6 @@
 # copy_code: true
 # index: false
 # toc: Table of Contents
+# search_limit: 100
 # theme: _theme
 # open: false

--- a/spec/fixtures/cli/help
+++ b/spec/fixtures/cli/help
@@ -16,16 +16,16 @@ Subcommands:
 
 Parameters:
   PATH:
-    Optional path to the markdown directory.
+    Path to the markdown directory [default: .].
     (Config option: path)
 
 Options:
   -p, --port NUMBER
-    Set server port number.
+    Set server port number [default: 3000].
     (Config option: port)
 
   -b, --bind ADDRESS
-    Set server listen address.
+    Set server listen address [default: 0.0.0.0].
     (Config option: bind)
 
   --no-auto-h1
@@ -67,6 +67,10 @@ Options:
   --toc FILE
     Generate a table of contents file. 
     (Config option: toc)
+
+  --search-limit LIMIT
+    Maximum number of results to show on the search page [default: 100].
+    (Config option: search_limit)
 
   --open
     Open the browser pointing at the madness webserver.


### PR DESCRIPTION
- Add `--search-limit` CLI option
- Add `search_limit` config option
- Change default search limit from 20 to 100
- Add `[default: X]` mentions in the CLI docopt
