### PR TITLE
add "file" parameter to slim renderer

### DIFF
--- a/lib/madness/server.rb
+++ b/lib/madness/server.rb
@@ -40,6 +40,7 @@ module Madness
         content: content, 
         type: doc.type,
         title: doc.title,
+        file: doc.file,
         nav: nav, 
         breadcrumbs: breadcrumbs
       }


### PR DESCRIPTION
Thanks for the great server to serve markdown! I appreciate your effort in having customization by themes. It covers almost all cases except the following one. I'd like to include in a slim template something like this:
```
div
  | Last updated 
  = File.mtime(file)
```
to give the timestamp of the last update of a served markdown file. I could achieve it only by modifying your code. If you think it's okay to expose the file parameter please merge the PR, build a new gem version, and push it to DockerHub.