### PR TITLE
Remove Rack:SSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@
 * [Displaying Additional File Types](#displaying-additional-file-types)
 * [Basic Authentication](#basic-authentication)
 * [Customizing Theme](#customizing-theme)
-* [Forcing HTTPS Connection](#forcing-https-connection)
 * [Docker Image](#docker-image)
 
 ## Install
@@ -333,15 +332,6 @@ If you are looking to implement a smaller CSS change, follow these steps:
 
 Note that this functionality is not guaranteed to stay as is in future 
 versions of madness.
-
-## Forcing HTTPS Connection
-
-To have Madness redirect HTTP traffic to HTTPS, set this environment 
-variable:
-
-```shell
-$ export MADNESS_FORCE_SSL=1
-```
 
 ## Docker Image
 

--- a/lib/madness/browser.rb
+++ b/lib/madness/browser.rb
@@ -12,9 +12,8 @@ module Madness
 
     # Returns a URL based on host, port and MADNESS_FORCE_SSL.
     def server_url
-      scheme = ENV['MADNESS_FORCE_SSL'] ? 'https' : 'http'
       url_host = ['0.0.0.0', '127.0.0.1'].include?(host) ? 'localhost' : host
-      "#{scheme}://#{url_host}:#{port}"
+      "http://#{url_host}:#{port}"
     end
 
     # Returns true if the server is running. Will attempt to connect

--- a/lib/madness/server_base.rb
+++ b/lib/madness/server_base.rb
@@ -1,5 +1,4 @@
 # require 'sinatra/reloader'
-require 'rack/ssl'
 require 'sinatra/base'
 require 'slim'
 
@@ -12,7 +11,6 @@ module Madness
     helpers ServerHelper
 
     Slim::Engine.set_options pretty: true
-    use Rack::SSL if ENV['MADNESS_FORCE_SSL']
     set :root, File.expand_path('../../', __dir__)
     set :environment, ENV['MADNESS_ENV'] || :production
     set :server, :puma

--- a/madness.gemspec
+++ b/madness.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'naturally', '~> 2.2'
   s.add_runtime_dependency 'os', '~> 1.0'
   s.add_runtime_dependency 'puma', '~> 5.1'
-  s.add_runtime_dependency 'rack-ssl', '~> 1.4'
   s.add_runtime_dependency 'requires', '~> 0.1'
   s.add_runtime_dependency 'sinatra', '~> 2.0', '>= 2.0.5'
   s.add_runtime_dependency 'slim', '~> 4.0'


### PR DESCRIPTION
`Rack:SSL` is a very outdated gem, which provides near zero benefits in today's common practice setups.

Is it safe to remove it?

Discussion: https://github.com/DannyBen/madness/discussions/119