### PR TITLE
[[Link]] style shortlink support, configurable through .yml file

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@
 [![Build Status](https://github.com/DannyBen/madness/workflows/Test/badge.svg)](https://github.com/DannyBen/madness/actions?query=workflow%3ATest)
 [![Maintainability](https://api.codeclimate.com/v1/badges/fa440dc4dbf895734d74/maintainability)](https://codeclimate.com/github/DannyBen/madness/maintainability)
 
+--- 
+## Differences from [original](https://github.com/DannyBen/madness)
+
+### support for link format used by smart-notes apps like Obsidian. 
+
+Markdown based smart-notes apps frequently use a non-standard link format in the form of `[[Link]]` where Link is equally the link text and the name of the local markdown file to link to. `[[Link]]` would therefore translate to `[Link](./Link.md)`
+
 ---
 
 ## Screenshots (click to zoom)
@@ -176,6 +183,9 @@ expose_extensions: ~
 # exclude directories that match these regular expressions
 # note that this is an array
 exclude: ['^[a-z_\-0-9]+$']
+
+# support for internal links in the form [[Link Title and Filename]]
+shortlinks: true
 ```
 
 For convenience, you can generate a template config file by running:

--- a/lib/madness/document.rb
+++ b/lib/madness/document.rb
@@ -67,6 +67,12 @@ module Madness
 
     def markdown
       @markdown ||= File.read file
+      @markdown = shortlinks(@markdown) if config.shortlinks
+      @markdown
+    end
+
+    def shortlinks(raw)
+      raw.gsub(/\[\[([^\]]+)\]\]/) { "[#{Regexp.last_match(1)}](./#{Regexp.last_match(1).to_href}.md)" }
     end
 
     def doc

--- a/lib/madness/settings.rb
+++ b/lib/madness/settings.rb
@@ -63,7 +63,8 @@ module Madness
         auth: false,
         auth_realm: 'Madness',
         expose_extensions: nil,
-        exclude: [/^[a-z_\-0-9]+$/]
+        exclude: [/^[a-z_\-0-9]+$/],
+        shortlinks: false
       }
     end
 
@@ -77,7 +78,7 @@ module Madness
       else
         {}
       end
-      
+
       result || {}
     end
 

--- a/lib/madness/templates/madness.yml
+++ b/lib/madness/templates/madness.yml
@@ -54,3 +54,7 @@ expose_extensions: ~
 # exclude directories that match these regular expressions
 # note that this is an array
 exclude: ['^[a-z_\-0-9]+$']
+
+# support for internal links in the form [[Link Title and Filename]]
+shortlinks: false
+


### PR DESCRIPTION
This is for your consideration. I've added support for smart-note style links mentioned in [issue 124](https://github.com/DannyBen/madness/issues/124) as simple pre-processing step before the document is converted.

Support for this non-standard link format is off by default and can be activated through the .madness.yml file