### PR TITLE
Remove some styling related command line flags

### DIFF
--- a/lib/madness/command_line.rb
+++ b/lib/madness/command_line.rb
@@ -66,17 +66,8 @@ module Madness
       config.toc          = args['--toc']  if args['--toc']
       config.auth         = args['--auth'] if args['--auth']
       config.auth_realm   = args['--auth-realm'] if args['--auth-realm']
-
-      config.auto_h1      = false   if args['--no-auto-h1']
-      config.auto_nav     = false   if args['--no-auto-nav']
-      config.sidebar      = false   if args['--no-sidebar']
-      config.highlighter  = false   if args['--no-syntax']
-      config.line_numbers = false   if args['--no-line-numbers']
-      config.copy_code    = false   if args['--no-copy-code']
-      config.shortlinks   = true    if args['--shortlinks']
-      config.open         = true    if args['--open']
-
-      config.theme = File.expand_path(args['--theme'], config.path) if args['--theme']
+      config.open         = true if args['--open']
+      config.theme        = File.expand_path(args['--theme'], config.path) if args['--theme']
     end
 
     # Generate index and toc, if requested by the user.

--- a/lib/madness/docopt.txt
+++ b/lib/madness/docopt.txt
@@ -28,37 +28,6 @@ Options:
     Set server listen address.
     (Config option: bind, default: 0.0.0.0)
 
-  --no-auto-h1
-    By default, if a markdown document does not start with an H1 caption,
-    it will be added automatically based on the file name. To disable this
-    behavior, use --no-auto-h1.
-    (Config option: auto_h1)
-
-  --no-syntax
-    Disable code syntax highlighting.
-    (Config option: highlighter)
-
-  --no-line-numbers
-    Disable line numbering for syntax highlighter.
-    (Config option: line_numbers)
-
-  --no-copy-code
-    Disable copy to cliboard icon for code snippets.
-    (Config option: copy_code)
-
-  --no-sidebar
-    Disable sidebar navigation.
-    (Config option: sidebar)
-
-  --no-auto-nav
-    Disable automatic generation of footer navigation for folder README 
-    files.
-    (Config option: auto_nav)
-
-  --shortlinks
-    Enable support for [[Short Links]].
-    (Config option: shortlinks)
-
   --theme FOLDER
     Use a custom theme. FOLDER is either absolute or relative to the main
     documentation path.
@@ -86,13 +55,10 @@ Options:
 Examples:
   madness
   madness docs
-  madness docs --no-auto-h1 -p 4567
+  madness docs -p 4567
   madness docs --open
-  madness --no-sidebar --no-auto-nav
   madness --toc "Table of Contents.md" --and-quit
   madness --auth user:secret --port 4000
   madness --theme _mytheme
   madness create config
   madness create theme
-
-

--- a/spec/fixtures/cli/help
+++ b/spec/fixtures/cli/help
@@ -28,37 +28,6 @@ Options:
     Set server listen address.
     (Config option: bind, default: 0.0.0.0)
 
-  --no-auto-h1
-    By default, if a markdown document does not start with an H1 caption,
-    it will be added automatically based on the file name. To disable this
-    behavior, use --no-auto-h1.
-    (Config option: auto_h1)
-
-  --no-syntax
-    Disable code syntax highlighting.
-    (Config option: highlighter)
-
-  --no-line-numbers
-    Disable line numbering for syntax highlighter.
-    (Config option: line_numbers)
-
-  --no-copy-code
-    Disable copy to cliboard icon for code snippets.
-    (Config option: copy_code)
-
-  --no-sidebar
-    Disable sidebar navigation.
-    (Config option: sidebar)
-
-  --no-auto-nav
-    Disable automatic generation of footer navigation for folder README 
-    files.
-    (Config option: auto_nav)
-
-  --shortlinks
-    Enable support for [[Short Links]].
-    (Config option: shortlinks)
-
   --theme FOLDER
     Use a custom theme. FOLDER is either absolute or relative to the main
     documentation path.
@@ -86,9 +55,8 @@ Options:
 Examples:
   madness
   madness docs
-  madness docs --no-auto-h1 -p 4567
+  madness docs -p 4567
   madness docs --open
-  madness --no-sidebar --no-auto-nav
   madness --toc "Table of Contents.md" --and-quit
   madness --auth user:secret --port 4000
   madness --theme _mytheme


### PR DESCRIPTION
Remove these options from the CLI (they are still available normally in the config file)

- --no-auto-h1
- --no-syntax
- --no-line-numbers
- --no-copy-code
- --no-sidebar
- --no-auto-nav
- --shortlinks

Closes #74