### PR TITLE
Fix: errors in schema

### DIFF
--- a/schemas/madness.json
+++ b/schemas/madness.json
@@ -147,9 +147,16 @@
         "expose_extensions": {
             "title": "expose extensions",
             "description": "Whether to show files with these extensions in the navigation and search of the current site",
-            "type": "string",
-            "examples": [
-                "pdf,docx,xlsx,txt"
+            "oneOf": [
+                {
+                    "type": "string",
+                    "examples": [
+                        "pdf,docx,xlsx,txt"
+                    ]
+                },
+                {
+                    "type": "null"
+                }
             ]
         },
         "exclude": {

--- a/schemas/madness.json
+++ b/schemas/madness.json
@@ -115,6 +115,38 @@
                 }
             ]
         },
+        "source_link": {
+            "title": "source link",
+            "description": "A link to the page source of the current site",
+            "oneOf": [
+                {
+                    "type": "string",
+                    "minLength": 1,
+                    "examples": [
+                        "http://example.com/%{path}"
+                    ]
+                },
+                {
+                    "type": "null"
+                }
+            ]
+        },
+        "source_link_label": {
+            "title": "source link label",
+            "type": "string",
+            "minLength": 1,
+            "default": "Page Source"
+        },
+        "source_link_pos": {
+            "title": "source link pos",
+            "description": "A link of page source position of the current site",
+            "type": "string",
+            "enum": [
+                "top",
+                "bottom"
+            ],
+            "default": "bottom"
+        },
         "open": {
             "title": "open",
             "description": "Whether to open the server URL in the browser of the current site",

--- a/schemas/madness.json
+++ b/schemas/madness.json
@@ -133,6 +133,7 @@
         },
         "source_link_label": {
             "title": "source link label",
+            "description": "A link of page source label of the current site",
             "type": "string",
             "minLength": 1,
             "default": "Page Source"


### PR DESCRIPTION
- [x] permit null for `expose_extensions`
- [x] add missing `source_link`, `source_link_label`, `source_link_pos` properties

Related to #152