### PR TITLE
Feature: add conditional requirements for properties

### DIFF
--- a/lib/madness/templates/madness.yml
+++ b/lib/madness/templates/madness.yml
@@ -65,7 +65,8 @@ open: false
 
 # provide user:password for basic authentication, for example:
 # auth: admin:s3cr3t
-auth: false
+# by default it's false
+auth: admin:s3cr3t
 
 # if auth is enabled, specify auth realm name
 auth_zone: Restricted Documentation

--- a/schemas/madness.json
+++ b/schemas/madness.json
@@ -213,6 +213,9 @@
     },
     "dependencies": {
         "auth_zone": {
+            "required": [
+                "auth"
+            ],
             "properties": {
                 "auth": {
                     "type": "string"

--- a/schemas/madness.json
+++ b/schemas/madness.json
@@ -211,5 +211,14 @@
             }
         }
     },
+    "dependencies": {
+        "auth_zone": {
+            "properties": {
+                "auth": {
+                    "type": "string"
+                }
+            }
+        }
+    },
     "additionalProperties": false
 }


### PR DESCRIPTION
- `auth` is required to be present when `auth_zone` is used
- `auth` is required to be `string` when `auth_zone` is used
- `auth` value changed to `admin:s3cr3t` while default is mentioned in comment above