### PR TITLE
Add test to ensure headings with diacritics get the correct href and ID

### DIFF
--- a/edge/README.md
+++ b/edge/README.md
@@ -14,8 +14,9 @@ or build your own image with [this Dockerfile](Dockerfile).
 ## Using Ruby
 
 ```bash
-git clone --depth 1 https://github.com/DannyBen/madness.git
+git clone https://github.com/DannyBen/madness.git
 cd madness
+git checkout <the branch of the PR>   # optional, if not testing `master`
 gem build madness.gemspec
 gem install madness*.gem
 cd ..

--- a/spec/approvals/render/diacritics
+++ b/spec/approvals/render/diacritics
@@ -1,0 +1,7 @@
+<h2 id="table-of-contents">Table of Contents</h2>
+
+<ul>
+<li><a href="#2-4-prava-plastov-krabi-ky-pro-elektroniku">2.4. Úprava plastové krabičky pro elektroniku</a></li>
+</ul>
+
+<h2 id="2-4-prava-plastov-krabi-ky-pro-elektroniku">2.4. Úprava plastové krabičky pro elektroniku</h2>

--- a/spec/approvals/toc
+++ b/spec/approvals/toc
@@ -29,6 +29,7 @@
     1. [Unsafe HTML](/Style%20Guide/Unsafe%20HTML)
 1. [CHANGELOG](/CHANGELOG)
 1. [Code](/Code)
+1. [Diacritics](/Diacritics)
 1. [Double Escape](/Double%20Escape)
 1. [Extras](/Extras)
 1. [File](/File)

--- a/spec/fixtures/docroot/Diacritics.md
+++ b/spec/fixtures/docroot/Diacritics.md
@@ -1,0 +1,3 @@
+<!-- TOC -->
+
+## 2.4. Úprava plastové krabičky pro elektroniku

--- a/spec/madness/markdown_document_spec.rb
+++ b/spec/madness/markdown_document_spec.rb
@@ -20,6 +20,16 @@ describe MarkdownDocument do
       expect(subject.to_html).to match_approval('render/all-disabled')
     end
 
+    context 'when there are headings with diacritics' do
+      let(:file) { 'Diacritics' }
+
+      before { config.auto_toc = true }
+
+      it 'renders properly with matching href IDs' do
+        expect(subject.to_html).to match_approval('render/diacritics')
+      end
+    end
+
     context 'when all options are enabled' do
       before do
         config.auto_h1 = true


### PR DESCRIPTION
*Issue discovered in #158 and #159*

This PR simply adds a test to ensure the slug that is generated by madness matches the id generated by Red Carpet.