### PR TITLE
Update breadcrumbs href with a trailing slash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 Gemfile.lock
 
+/cache
 /coverage
 /debug.runfile
 /dev

--- a/app/views/_breadcrumbs.slim
+++ b/app/views/_breadcrumbs.slim
@@ -1,8 +1,8 @@
 - unless breadcrumbs.empty?
   .breadcrumbs
     - breadcrumbs.each do |item|
-      - if item.last
-        span = item.label
-      - else
+      - if item.href
         a href="#{item.href}" = item.label
         = " / "
+      - else
+        span = item.label

--- a/lib/madness/breadcrumbs.rb
+++ b/lib/madness/breadcrumbs.rb
@@ -29,7 +29,7 @@ module Madness
       parent, basename = File.split partial_path
       href = "#{config.base_uri}/#{partial_path}"
       href = "#{href}/" unless href.end_with? '/'
-      item = Breadcrumb.new label: basename.to_label, href:  href
+      item = Breadcrumb.new label: basename.to_label, href: href
       result = [item]
       result += breadcrumbs_maker parent unless parent == '.'
       result

--- a/lib/madness/breadcrumbs.rb
+++ b/lib/madness/breadcrumbs.rb
@@ -4,6 +4,8 @@ module Madness
   class Breadcrumbs
     using StringRefinements
 
+    Breadcrumb = Struct.new :label, :href, keyword_init: true
+
     attr_reader :path
 
     def initialize(path)
@@ -17,20 +19,17 @@ module Madness
   private
 
     def breadcrumbs
-      home = OpenStruct.new({ label: 'Home', href: "#{config.base_uri}/" })
+      home = Breadcrumb.new label: 'Home', href: "#{config.base_uri}/"
       result = breadcrumbs_maker(path).reverse.unshift home
-      result.last.last = true
+      result.last.href = nil
       result
     end
 
     def breadcrumbs_maker(partial_path)
       parent, basename = File.split partial_path
-      item = OpenStruct.new(
-        {
-          label: basename.to_label,
-          href:  "#{config.base_uri}/#{partial_path}/",
-        }
-      )
+      href = "#{config.base_uri}/#{partial_path}"
+      href = "#{href}/" unless href.end_with? '/'
+      item = Breadcrumb.new label: basename.to_label, href:  href
       result = [item]
       result += breadcrumbs_maker parent unless parent == '.'
       result

--- a/lib/madness/breadcrumbs.rb
+++ b/lib/madness/breadcrumbs.rb
@@ -28,7 +28,7 @@ module Madness
       item = OpenStruct.new(
         {
           label: basename.to_label,
-          href:  "#{config.base_uri}/#{partial_path}",
+          href:  "#{config.base_uri}/#{partial_path}/",
         }
       )
       result = [item]

--- a/spec/madness/breadcrumbs_spec.rb
+++ b/spec/madness/breadcrumbs_spec.rb
@@ -4,10 +4,10 @@ describe Breadcrumbs do
   describe '#links' do
     let(:links) { subject.links }
 
-    it 'returns an array of OpenStructs' do
+    it 'returns an array of Breadcrumb structs' do
       expect(links).to be_an Array
       expect(links.count).to eq 4
-      expect(links.first).to be_an OpenStruct
+      expect(links.first).to be_a described_class::Breadcrumb
     end
 
     it 'adds a home link' do
@@ -15,17 +15,13 @@ describe Breadcrumbs do
       expect(links.first.href).to eq '/'
     end
 
-    it 'adds a link to each element' do
+    it 'adds a link to all elements except the last one' do
       expect(links[1].label).to eq 'one'
       expect(links[1].href).to eq '/one/'
       expect(links[2].label).to eq 'two'
       expect(links[2].href).to eq '/one/two/'
       expect(links[3].label).to eq 'three'
-      expect(links[3].href).to eq '/one/two/three/'
-    end
-
-    it 'adds a last attribute to last element' do
-      expect(links.last.last).to be true
+      expect(links[3].href).to be_nil
     end
 
     context 'with sorted elements' do
@@ -37,7 +33,7 @@ describe Breadcrumbs do
         expect(links[2].label).to eq 'two'
         expect(links[2].href).to eq '/1. one/2. two/'
         expect(links[3].label).to eq 'three'
-        expect(links[3].href).to eq '/1. one/2. two/3. three/'
+        expect(links[3].href).to be_nil
       end
     end
 
@@ -48,7 +44,7 @@ describe Breadcrumbs do
       it 'prepends the links with the base_uri' do
         expect(links[1].href).to eq '/docs/one/'
         expect(links[2].href).to eq '/docs/one/two/'
-        expect(links[3].href).to eq '/docs/one/two/three/'
+        expect(links[3].href).to be_nil
       end
     end
   end

--- a/spec/madness/breadcrumbs_spec.rb
+++ b/spec/madness/breadcrumbs_spec.rb
@@ -17,11 +17,11 @@ describe Breadcrumbs do
 
     it 'adds a link to each element' do
       expect(links[1].label).to eq 'one'
-      expect(links[1].href).to eq '/one'
+      expect(links[1].href).to eq '/one/'
       expect(links[2].label).to eq 'two'
-      expect(links[2].href).to eq '/one/two'
+      expect(links[2].href).to eq '/one/two/'
       expect(links[3].label).to eq 'three'
-      expect(links[3].href).to eq '/one/two/three'
+      expect(links[3].href).to eq '/one/two/three/'
     end
 
     it 'adds a last attribute to last element' do
@@ -33,11 +33,11 @@ describe Breadcrumbs do
 
       it 'removes sorting markers from labels' do
         expect(links[1].label).to eq 'one'
-        expect(links[1].href).to eq '/1. one'
+        expect(links[1].href).to eq '/1. one/'
         expect(links[2].label).to eq 'two'
-        expect(links[2].href).to eq '/1. one/2. two'
+        expect(links[2].href).to eq '/1. one/2. two/'
         expect(links[3].label).to eq 'three'
-        expect(links[3].href).to eq '/1. one/2. two/3. three'
+        expect(links[3].href).to eq '/1. one/2. two/3. three/'
       end
     end
 
@@ -46,9 +46,9 @@ describe Breadcrumbs do
       after  { config.base_uri = nil }
 
       it 'prepends the links with the base_uri' do
-        expect(links[1].href).to eq '/docs/one'
-        expect(links[2].href).to eq '/docs/one/two'
-        expect(links[3].href).to eq '/docs/one/two/three'
+        expect(links[1].href).to eq '/docs/one/'
+        expect(links[2].href).to eq '/docs/one/two/'
+        expect(links[3].href).to eq '/docs/one/two/three/'
       end
     end
   end


### PR DESCRIPTION
cc #174

---

This PR adds a trailing slash to all links in the breadcrumbs.
In addition, the following internal changes were done:

1. The breadcrumbs array returns an array of named structs (`Breadcrumb`) instead of `OpenStruct`.
2. The last breadcrumb will have its `href` set to `nil`, instead of having the `last: true` attribute.
   Rationale:
   - The last element is never a link
   - The last element is the only element that can either be a file or a folder, and all links end with a `/` - which means the link may be inappropriate anyway.

