### PR TITLE
Fix inline Table of Contents invalid parsing of code blocks

### DIFF
--- a/lib/madness/inline_table_of_contents.rb
+++ b/lib/madness/inline_table_of_contents.rb
@@ -18,9 +18,7 @@ module Madness
 
     def markdown!
       result = ["#{caption}\n"]
-      text.lines(chomp: true).each do |line|
-        next unless meaningful_line? line
-
+      meaningful_lines.each do |line|
         matches = line.match(/^(?<level>\#{2,3})\s+(?<text>.+)/)
         next unless matches
 
@@ -28,6 +26,10 @@ module Madness
       end
 
       result.join "\n"
+    end
+
+    def meaningful_lines
+      text.lines(chomp: true).select { |line| meaningful_line? line }
     end
 
     def meaningful_line?(line)

--- a/lib/madness/inline_table_of_contents.rb
+++ b/lib/madness/inline_table_of_contents.rb
@@ -1,0 +1,54 @@
+module Madness
+  # Generate a markdown Table of Contents for a single document
+  class InlineTableOfContents
+    include ServerHelper
+    using StringRefinements
+
+    attr_reader :text
+
+    def initialize(text)
+      @text = text
+    end
+
+    def markdown
+      @markdown ||= markdown!
+    end
+
+  protected
+
+    def markdown!
+      result = ["#{caption}\n"]
+      text.lines(chomp: true).each do |line|
+        next unless line.start_with?('#', '```')
+        next if inside_code_block? line
+
+        matches = line.match(/^(?<level>\#{2,3})\s+(?<text>.+)/)
+        next unless matches
+
+        level = matches[:level].size - 2
+        text = matches[:text]
+
+        spacer = '  ' * level
+        result.push "#{spacer}- [#{text}](##{text.to_slug})"
+      end
+
+      result.join "\n"
+    end
+
+    def caption
+      @caption ||= config.auto_toc.is_a?(String) ? config.auto_toc : '## Table of Contents'
+    end
+
+    def inside_code_block?(line)
+      @marker ||= false
+
+      if !@marker && line.start_with?('```')
+        @marker = line[/^`{3,4}/]
+      elsif @marker && line.start_with?(@marker)
+        @marker = false
+      end
+
+      !!@marker
+    end
+  end
+end

--- a/lib/madness/inline_table_of_contents.rb
+++ b/lib/madness/inline_table_of_contents.rb
@@ -19,20 +19,24 @@ module Madness
     def markdown!
       result = ["#{caption}\n"]
       text.lines(chomp: true).each do |line|
-        next unless line.start_with?('#', '```')
-        next if inside_code_block? line
+        next unless meaningful_line? line
 
         matches = line.match(/^(?<level>\#{2,3})\s+(?<text>.+)/)
         next unless matches
 
-        level = matches[:level].size - 2
-        text = matches[:text]
-
-        spacer = '  ' * level
-        result.push "#{spacer}- [#{text}](##{text.to_slug})"
+        result.push toc_item(matches[:text], matches[:level].size - 2)
       end
 
       result.join "\n"
+    end
+
+    def meaningful_line?(line)
+      line.start_with?('#', '```') && !inside_code_block?(line)
+    end
+
+    def toc_item(text, level)
+      spacer = '  ' * level
+      "#{spacer}- [#{text}](##{text.to_slug})"
     end
 
     def caption

--- a/lib/madness/markdown_document.rb
+++ b/lib/madness/markdown_document.rb
@@ -74,30 +74,12 @@ module Madness
       config.highlighter ? HighlightRenderer : Redcarpet::Render::HTML
     end
 
-    def toc_caption
-      @toc_caption ||= if config.auto_toc.is_a?(String)
-        config.auto_toc
-      else
-        '## Table of Contents'
-      end
+    def toc
+      @toc ||= toc_handler.markdown
     end
 
-    def toc
-      result = ["#{toc_caption}\n"]
-      markdown.lines(chomp: true).each do |line|
-        next unless line.start_with? '#'
-
-        matches = line.match(/^(?<level>\#{2,3})\s+(?<text>.+)/)
-        next unless matches
-
-        level = matches[:level].size - 1
-        text = matches[:text]
-
-        spacer = '  ' * level
-        result.push "#{spacer}- [#{text}](##{text.to_slug})"
-      end
-
-      result.join "\n"
+    def toc_handler
+      @toc_handler ||= Madness::InlineTableOfContents.new markdown
     end
   end
 end

--- a/lib/madness/table_of_contents.rb
+++ b/lib/madness/table_of_contents.rb
@@ -1,5 +1,5 @@
 module Madness
-  # Generate a markdown Table of Contents
+  # Generate a markdown Table of Contents for the entire site
   class TableOfContents
     include ServerHelper
 

--- a/spec/approvals/inline-toc
+++ b/spec/approvals/inline-toc
@@ -1,0 +1,5 @@
+## Table of Contents
+
+- [Header 2](#header-2)
+  - [Level 3 header](#level-3-header)
+- [Another Header 2](#another-header-2)

--- a/spec/approvals/toc
+++ b/spec/approvals/toc
@@ -40,5 +40,6 @@
 1. [File with H1 alt](/File%20with%20H1%20alt)
 1. [File with Shortlink](/File%20with%20Shortlink)
 1. [File with Spaces](/File%20with%20Spaces)
+1. [File with TOC and Code](/File%20with%20TOC%20and%20Code)
 1. [File with TOC](/File%20with%20TOC)
 1. [File without H1](/File%20without%20H1)

--- a/spec/fixtures/docroot/File with TOC and Code.md
+++ b/spec/fixtures/docroot/File with TOC and Code.md
@@ -1,0 +1,35 @@
+# File with TOC and Code
+
+<!-- TOC -->
+
+This file ensures that headers in code blocks (including nested code blocks)
+are ignored in TOC generation
+
+````
+
+## Header trap (should not be included)
+
+The below is displayed as is (unparsed)
+
+```
+## Code block in code block (also a trap)
+```
+
+````
+
+```markdown
+## Header in code block with language identifier
+```
+
+## Header 2
+
+Some text
+
+### Level 3 header
+
+More text
+
+## Another Header 2
+
+Even more text
+

--- a/spec/madness/inline_table_of_contents_spec.rb
+++ b/spec/madness/inline_table_of_contents_spec.rb
@@ -1,0 +1,11 @@
+describe InlineTableOfContents do
+  subject { described_class.new markdown }
+
+  let(:markdown) { File.read 'spec/fixtures/docroot/File with TOC and Code.md' }
+
+  describe '#markdown' do
+    it 'returns a markdown table of contents' do
+      expect(subject.markdown).to match_approval('inline-toc')
+    end
+  end
+end


### PR DESCRIPTION
cc #173 

This PR refactors the inline Table of Contents in order to:

1. Make the Table of Contents parser aware of code blocks, and ignore strings that look like markdown headers inside them.
2. Separate the handling of the inline Table of Contents to a new dedicated class.
