### PR TITLE
Fix inline TOC for Pandoc header slug rules

### DIFF
--- a/lib/madness/inline_table_of_contents.rb
+++ b/lib/madness/inline_table_of_contents.rb
@@ -36,10 +36,8 @@ module Madness
       level = matches[:level].size - 2
 
       spacer = '  ' * level
-      slug = text.to_slug
+      slug = text.to_slug config.renderer
 
-      # pandoc removes leading numbers and dots from header slugs, we do the same
-      slug = slug.remove(/^[\d\-]+/) if config.renderer == 'pandoc'
       "#{spacer}- [#{text}](##{slug})"
     end
 

--- a/lib/madness/refinements/string_refinements.rb
+++ b/lib/madness/refinements/string_refinements.rb
@@ -15,7 +15,7 @@ module Madness
         result = downcase.strip
 
         if renderer == 'pandoc'
-          result.remove(/[^a-z0-9 ]/).gsub(' ', '-')
+          result.remove(/[^a-z0-9 ]/).tr(' ', '-')
         else
           result.gsub(/[^[:alnum:]]/, '-').squeeze('-').remove(/(^-|-$)/)
         end

--- a/lib/madness/refinements/string_refinements.rb
+++ b/lib/madness/refinements/string_refinements.rb
@@ -11,8 +11,14 @@ module Madness
         Addressable::URI.escape self
       end
 
-      def to_slug
-        downcase.strip.gsub(/[^[:alnum:]]/, '-').squeeze('-').remove(/(^-|-$)/)
+      def to_slug(renderer = nil)
+        result = downcase.strip
+
+        if renderer == 'pandoc'
+          result.remove(/[^a-z0-9 ]/).gsub(' ', '-')
+        else
+          result.gsub(/[^[:alnum:]]/, '-').squeeze('-').remove(/(^-|-$)/)
+        end
       end
 
       # This is here so we can have one place that defines how to convert

--- a/spec/madness/refinements/string_refinements_spec.rb
+++ b/spec/madness/refinements/string_refinements_spec.rb
@@ -25,7 +25,7 @@ describe StringRefinements do
     end
 
     context 'with pandoc renderer' do
-      subject { '& & Tom & & Jerry & &'}
+      subject { '& & Tom & & Jerry & &' }
 
       it 'removes symbols before converting, does not squeeze dashes and leaves trailing and keeps edge dashes' do
         expect(subject.to_slug 'pandoc').to eq '--tom---jerry--'

--- a/spec/madness/refinements/string_refinements_spec.rb
+++ b/spec/madness/refinements/string_refinements_spec.rb
@@ -23,6 +23,14 @@ describe StringRefinements do
         expect(subject.to_slug).to eq 'café-müller-in-münchen-123'
       end
     end
+
+    context 'with pandoc renderer' do
+      subject { '& & Tom & & Jerry & &'}
+
+      it 'removes symbols before converting, does not squeeze dashes and leaves trailing and keeps edge dashes' do
+        expect(subject.to_slug 'pandoc').to eq '--tom---jerry--'
+      end
+    end
   end
 
   describe '#label' do


### PR DESCRIPTION
cc #190 

It seems (assumed...) that pandoc recently changed how it generates ID slugs for headers, so this PR makes the `String#to_slug` method renderer-aware.

A: This no longer seems to be true, so removed:

```ruby
# pandoc removes leading numbers and dots from header slugs, we do the same
slug = slug.remove(/^[\d\-]+/) if config.renderer == 'pandoc'
```

B: Pandoc seems to remove symbols prior to converting to hyphen-case, and it does not squeeze dashes nor removes leading/trailing dashes. We do the same:

```ruby
def to_slug(renderer = nil)
  result = downcase.strip

  if renderer == 'pandoc'
    result.remove(/[^a-z0-9 ]/).tr(' ', '-')
  else
    result.gsub(/[^[:alnum:]]/, '-').squeeze('-').remove(/(^-|-$)/)
  end
end
```

Tested against pandoc 3.2:

```shell
$ pandoc --version
pandoc 3.2
Features: +server +lua
Scripting engine: Lua 5.4
```