### PR TITLE
Remove Filewatcher dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
-      matrix: { ruby: ['3.2', '3.3', '3.4'] }
+      matrix: { ruby: ['3.2', '3.3', '3.4', '4,0'] }
 
     steps:
     - name: Checkout code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
-      matrix: { ruby: ['3.2', '3.3', '3.4', '4,0'] }
+      matrix: { ruby: ['3.2', '3.3', '3.4', '4.0'] }
 
     steps:
     - name: Checkout code

--- a/Gemfile
+++ b/Gemfile
@@ -2,11 +2,10 @@ source 'https://rubygems.org'
 
 group :development do
   gem 'debug'
-  gem 'filewatcher-cli', require: false
   gem 'lp'
   gem 'pretty_trace'
-  gem 'runfile', '>= 1.0', require: false
-  gem 'runfile-tasks', '>= 1.0', require: false
+  gem 'runfile', require: false
+  gem 'runfile-tasks', require: false
   gem 'sasstool', require: false
 end
 

--- a/tasks/css.runfile
+++ b/tasks/css.runfile
@@ -1,18 +1,13 @@
 summary 'CSS operations'
 
 help   'Generate public CSS'
-usage  'generate [--watch]'
-option '--watch, -w', 'Watch for changes and regenerate'
+usage  'generate'
 action :generate do |args|
   require 'sasstool'
 
-  if args['--watch']
-    exec "filewatcher --immediate 'app/styles/*.scss' 'bundle exec run css generate'"
-  else
-    target = "app/public/css"
-    Sasstool::Renderer.new("app/styles/main.scss").save target
-    puts "Saved #{target}"
-  end
+  target = "app/public/css"
+  Sasstool::Renderer.new("app/styles/main.scss").save target
+  puts "Saved #{target}"
 end
 
 help   "Generate rouge CSS"


### PR DESCRIPTION
Filewatcher was required in two places: Through sasstool (which [now uses Listen instead](https://github.com/DannyBen/sasstool/pull/8)), and directly, for a CSS runfile task.

This is a development-dependencies only change, no release needed.
Closes #204 